### PR TITLE
Update fields to add missing meta fields

### DIFF
--- a/classfield/fields.py
+++ b/classfield/fields.py
@@ -19,6 +19,8 @@ class FakeModel(six.with_metaclass(FakeType, object)):
     class _meta:
         concrete_fields = []
         fields = []
+        app_label = 'ClassField'
+        model_name = 'ClassFields FakeModel'
 
 
 class ClassFieldFakeRemoteField(object):


### PR DESCRIPTION
Fixing issue:

`AttributeError: type object '_meta' has no attribute 'model_name'`

When Making migrations using ClassFields as an attribute.
